### PR TITLE
Features/blinding factor

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,13 +1,13 @@
 use crate::crypto;
 
-// AVERAGE_DELAY SHOULD NEVER BE ZERO!!
-pub const AVERAGE_DELAY: f64 = 10.0;
-// k in the Sphinx paper. Measured in bytes; 128 bits.
-pub const SECURITY_PARAMETER: usize = 16;
-// r in the Sphinx paper
-pub const MAX_PATH_LENGTH: usize = 5;
-pub const ROUTING_KEYS_LENGTH: usize =
-    crypto::STREAM_CIPHER_KEY_SIZE + INTEGRITY_MAC_KEY_SIZE + PAYLOAD_KEY_SIZE;
+pub const AVERAGE_DELAY: f64 = 10.0; // AVERAGE_DELAY SHOULD NEVER BE ZERO!!
+pub const SECURITY_PARAMETER: usize = 16; // k in the Sphinx paper. Measured in bytes; 128 bits.
+pub const MAX_PATH_LENGTH: usize = 5; // r in the Sphinx paper
+pub const BLINDING_FACTOR_SIZE: usize = 2 * SECURITY_PARAMETER;
+pub const ROUTING_KEYS_LENGTH: usize = crypto::STREAM_CIPHER_KEY_SIZE
+    + INTEGRITY_MAC_KEY_SIZE
+    + PAYLOAD_KEY_SIZE
+    + BLINDING_FACTOR_SIZE;
 pub const HKDF_INPUT_SEED: &[u8; 97] = b"Dwste mou enan moxlo arketa makru kai ena upomoxlio gia na ton topothetisw kai tha kinisw thn gh.";
 pub const STREAM_CIPHER_OUTPUT_LENGTH: usize = (3 * MAX_PATH_LENGTH + 3) * SECURITY_PARAMETER;
 pub const DESTINATION_ADDRESS_LENGTH: usize = 2 * SECURITY_PARAMETER;

--- a/src/header/keys.rs
+++ b/src/header/keys.rs
@@ -5,7 +5,8 @@ use hkdf::Hkdf;
 use sha2::Sha256;
 
 use crate::constants::{
-    HKDF_INPUT_SEED, INTEGRITY_MAC_KEY_SIZE, PAYLOAD_KEY_SIZE, ROUTING_KEYS_LENGTH,
+    BLINDING_FACTOR_SIZE, HKDF_INPUT_SEED, INTEGRITY_MAC_KEY_SIZE, PAYLOAD_KEY_SIZE,
+    ROUTING_KEYS_LENGTH,
 };
 use crate::crypto;
 use crate::crypto::{compute_keyed_hmac, CURVE_GENERATOR, STREAM_CIPHER_KEY_SIZE};
@@ -16,12 +17,14 @@ pub type HeaderIntegrityMacKey = [u8; INTEGRITY_MAC_KEY_SIZE];
 // TODO: perhaps change PayloadKey to a Vec considering it's almost 200 bytes long?
 // we will lose length assertions but won't need to copy all that data every single function call
 pub type PayloadKey = [u8; PAYLOAD_KEY_SIZE];
+pub type BlindingFactor = [u8; BLINDING_FACTOR_SIZE];
 
 #[derive(Clone)]
 pub struct RoutingKeys {
     pub stream_cipher_key: StreamCipherKey,
     pub header_integrity_hmac_key: HeaderIntegrityMacKey,
     pub payload_key: PayloadKey,
+    pub blinding_factor: BlindingFactor,
 }
 
 impl RoutingKeys {
@@ -47,10 +50,15 @@ impl RoutingKeys {
         payload_key.copy_from_slice(&output[i..i + PAYLOAD_KEY_SIZE]);
         i += PAYLOAD_KEY_SIZE;
 
+        let mut blinding_factor: [u8; BLINDING_FACTOR_SIZE] = Default::default();
+        blinding_factor.copy_from_slice(&output[i..i + BLINDING_FACTOR_SIZE]);
+        i += BLINDING_FACTOR_SIZE;
+
         Self {
             stream_cipher_key,
             header_integrity_hmac_key,
             payload_key,
+            blinding_factor,
         }
     }
 }
@@ -90,13 +98,12 @@ impl KeyMaterial {
             .iter()
             .scan(initial_secret, |accumulator, node| {
                 let shared_key = Self::compute_shared_key(node.pub_key, &accumulator);
+                let routing_keys = RoutingKeys::derive(shared_key);
 
                 // TODO: if we're on last iteration, do NOT compute_blinding_factor (no need for it)
-                *accumulator *= Self::compute_blinding_factor(shared_key, &accumulator);
-
-                Some(shared_key)
+                *accumulator *= Scalar::from_bytes_mod_order(routing_keys.blinding_factor);
+                Some(routing_keys)
             })
-            .map(RoutingKeys::derive)
             .collect();
 
         Self {
@@ -223,11 +230,9 @@ mod deriving_key_material {
             for i in 0..3 {
                 let expected_shared_key =
                     KeyMaterial::compute_shared_key(route[i].pub_key, &expected_accumulator);
-                let expected_blinder = KeyMaterial::compute_blinding_factor(
-                    expected_shared_key,
-                    &expected_accumulator,
-                );
-                expected_accumulator *= &expected_blinder;
+                let expected_routing_keys = RoutingKeys::derive(expected_shared_key);
+                expected_accumulator *=
+                    Scalar::from_bytes_mod_order(expected_routing_keys.blinding_factor);
                 let expected_routing_keys = RoutingKeys::derive(expected_shared_key);
                 assert_eq!(expected_routing_keys, key_material.routing_keys[i])
             }
@@ -264,5 +269,6 @@ pub fn routing_keys_fixture() -> RoutingKeys {
         stream_cipher_key: [1u8; crypto::STREAM_CIPHER_KEY_SIZE],
         header_integrity_hmac_key: [2u8; INTEGRITY_MAC_KEY_SIZE],
         payload_key: [3u8; PAYLOAD_KEY_SIZE],
+        blinding_factor: [4u8; BLINDING_FACTOR_SIZE],
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -4,7 +4,7 @@ use curve25519_dalek::scalar::Scalar;
 use crate::constants::HEADER_INTEGRITY_MAC_SIZE;
 use crate::crypto::{compute_keyed_hmac, PublicKey, SharedKey};
 use crate::header::filler::Filler;
-use crate::header::keys::{PayloadKey, StreamCipherKey};
+use crate::header::keys::{BlindingFactor, PayloadKey, StreamCipherKey};
 use crate::header::routing::nodes::EncryptedRoutingInformation;
 use crate::header::routing::{EncapsulatedRoutingInformation, ENCRYPTED_ROUTING_INFO_SIZE};
 use crate::route::{Destination, Node, NodeAddressBytes};
@@ -88,7 +88,8 @@ impl SphinxHeader {
         }
 
         // blind the shared_secret in the header
-        let new_shared_secret = self.blind_the_shared_secret(shared_secret, shared_key);
+        let new_shared_secret =
+            self.blind_the_shared_secret(shared_secret, routing_keys.blinding_factor);
 
         let (next_hop_address, encapsulated_next_hop) = Self::unwrap_routing_information(
             self.routing_info.enc_routing_information,
@@ -136,15 +137,9 @@ impl SphinxHeader {
     fn blind_the_shared_secret(
         &self,
         shared_secret: PublicKey,
-        shared_key: SharedKey,
+        blinding_factor: BlindingFactor,
     ) -> PublicKey {
-        let hmac_full = compute_keyed_hmac(
-            shared_secret.to_bytes().to_vec(),
-            &shared_key.to_bytes().to_vec(),
-        );
-        let mut hmac = [0u8; 32];
-        hmac.copy_from_slice(&hmac_full[..32]);
-        let blinding_factor = Scalar::from_bytes_mod_order(hmac);
+        let blinding_factor = Scalar::from_bytes_mod_order(blinding_factor);
         shared_secret * blinding_factor
     }
 }


### PR DESCRIPTION
I changed how we compute the blinding factors - now, a particular blinding factor is generated when we derive all routing keys from the computed shared key. This might save us some time in deriving keys (worth checking whether indeed and if yes, how much) since we run only the derive function, but we don't have to compute again HMAC separately. 