### PR TITLE
Features/add version into sphinx

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,4 +23,4 @@ pub const FINAL_NODE_META_INFO_LENGTH: usize =
     DESTINATION_ADDRESS_LENGTH + IDENTIFIER_LENGTH + FLAG_LENGTH + VERSION_LENGTH; // the meta info for the final hop might be of a different size
 pub const FLAG_LENGTH: usize = 1;
 pub const PAYLOAD_SIZE: usize = 1024;
-pub const VERSION_LENGTH: usize = 5; // since version is represented as x.x.x
+pub const VERSION_LENGTH: usize = 3; // since version is represented as 3 u8 values: major, minor and patch

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,8 +17,10 @@ pub const INTEGRITY_MAC_KEY_SIZE: usize = SECURITY_PARAMETER;
 pub const HEADER_INTEGRITY_MAC_SIZE: usize = SECURITY_PARAMETER;
 pub const PAYLOAD_KEY_SIZE: usize = 192; // must be 192 because of the Lioness implementation we're using
 pub const DELAY_LENGTH: usize = 8; // how many bytes we will use to encode the delay
-pub const NODE_META_INFO_SIZE: usize = NODE_ADDRESS_LENGTH + FLAG_LENGTH + DELAY_LENGTH; // the meta info is all the information from sender to the node like: where to forward the packet, what is the delay etc
+pub const NODE_META_INFO_SIZE: usize =
+    NODE_ADDRESS_LENGTH + FLAG_LENGTH + DELAY_LENGTH + VERSION_LENGTH; // the meta info is all the information from sender to the node like: where to forward the packet, what is the delay etc
 pub const FINAL_NODE_META_INFO_LENGTH: usize =
-    DESTINATION_ADDRESS_LENGTH + IDENTIFIER_LENGTH + FLAG_LENGTH; // the meta info for the final hop might be of a different size
+    DESTINATION_ADDRESS_LENGTH + IDENTIFIER_LENGTH + FLAG_LENGTH + VERSION_LENGTH; // the meta info for the final hop might be of a different size
 pub const FLAG_LENGTH: usize = 1;
 pub const PAYLOAD_SIZE: usize = 1024;
+pub const VERSION_LENGTH: usize = 5; // since version is represented as x.x.x

--- a/src/header/routing/destination.rs
+++ b/src/header/routing/destination.rs
@@ -34,11 +34,7 @@ impl FinalRoutingInformation {
 
         Self {
             flag: FINAL_HOP,
-            version: Version {
-                major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
-                minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
-                patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
-            },
+            version: Version::new(),
             destination: dest.address,
             identifier: dest.identifier,
         }

--- a/src/header/routing/destination.rs
+++ b/src/header/routing/destination.rs
@@ -6,9 +6,10 @@ use crate::crypto::STREAM_CIPHER_INIT_VECTOR;
 use crate::header::filler::{Filler, FILLER_STEP_SIZE_INCREASE};
 use crate::header::keys::StreamCipherKey;
 use crate::header::routing::nodes::EncryptedRoutingInformation;
-use crate::header::routing::{RoutingFlag, ENCRYPTED_ROUTING_INFO_SIZE, FINAL_HOP};
+use crate::header::routing::{RoutingFlag, Version, ENCRYPTED_ROUTING_INFO_SIZE, FINAL_HOP};
 use crate::route::{Destination, DestinationAddressBytes, SURBIdentifier};
 use crate::utils;
+use std::convert::TryInto;
 
 // this is going through the following transformations:
 /*
@@ -20,6 +21,7 @@ use crate::utils;
 // because it seems weird that say 'encrypt' requires route_len argument
 pub(super) struct FinalRoutingInformation {
     flag: RoutingFlag,
+    version: Version,
     destination: DestinationAddressBytes,
     // in paper delta
     identifier: SURBIdentifier, // in paper I
@@ -32,6 +34,9 @@ impl FinalRoutingInformation {
 
         Self {
             flag: FINAL_HOP,
+            version: Version {
+                value: env!("CARGO_PKG_VERSION").to_string(),
+            },
             destination: dest.address,
             identifier: dest.identifier,
         }
@@ -60,6 +65,7 @@ impl FinalRoutingInformation {
             value: vec![self.flag]
                 .iter()
                 .cloned()
+                .chain(self.version.value.as_bytes().iter().cloned())
                 .chain(self.destination.iter().cloned())
                 .chain(self.identifier.iter().cloned())
                 .chain(padding.iter().cloned())

--- a/src/header/routing/destination.rs
+++ b/src/header/routing/destination.rs
@@ -35,7 +35,9 @@ impl FinalRoutingInformation {
         Self {
             flag: FINAL_HOP,
             version: Version {
-                value: env!("CARGO_PKG_VERSION").to_string(),
+                major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+                minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+                patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
             },
             destination: dest.address,
             identifier: dest.identifier,
@@ -65,7 +67,7 @@ impl FinalRoutingInformation {
             value: vec![self.flag]
                 .iter()
                 .cloned()
-                .chain(self.version.value.as_bytes().iter().cloned())
+                .chain(self.version.to_bytes().iter().cloned())
                 .chain(self.destination.iter().cloned())
                 .chain(self.identifier.iter().cloned())
                 .chain(padding.iter().cloned())

--- a/src/header/routing/mod.rs
+++ b/src/header/routing/mod.rs
@@ -23,9 +23,16 @@ pub const FINAL_HOP: RoutingFlag = 2;
 
 pub type RoutingFlag = u8;
 pub struct Version {
-    value: String,
+    major: u8,
+    minor: u8,
+    patch: u8,
 }
 
+impl Version {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        vec![self.major, self.minor, self.patch]
+    }
+}
 // the derivation is only required for the tests. please remove it in production
 #[derive(Clone)]
 pub struct EncapsulatedRoutingInformation {

--- a/src/header/routing/mod.rs
+++ b/src/header/routing/mod.rs
@@ -22,6 +22,9 @@ pub const FORWARD_HOP: RoutingFlag = 1;
 pub const FINAL_HOP: RoutingFlag = 2;
 
 pub type RoutingFlag = u8;
+pub struct Version {
+    value: String,
+}
 
 // the derivation is only required for the tests. please remove it in production
 #[derive(Clone)]

--- a/src/header/routing/mod.rs
+++ b/src/header/routing/mod.rs
@@ -22,6 +22,8 @@ pub const FORWARD_HOP: RoutingFlag = 1;
 pub const FINAL_HOP: RoutingFlag = 2;
 
 pub type RoutingFlag = u8;
+
+#[derive(Default)]
 pub struct Version {
     major: u8,
     minor: u8,
@@ -29,6 +31,14 @@ pub struct Version {
 }
 
 impl Version {
+    pub fn new() -> Self {
+        Self {
+            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
+        }
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         vec![self.major, self.minor, self.patch]
     }

--- a/src/header/routing/nodes.rs
+++ b/src/header/routing/nodes.rs
@@ -40,7 +40,9 @@ impl RoutingInformation {
         RoutingInformation {
             flag: FORWARD_HOP,
             version: Version {
-                value: env!("CARGO_PKG_VERSION").to_string(),
+                major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+                minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+                patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
             },
             node_address,
             delay,
@@ -53,7 +55,7 @@ impl RoutingInformation {
 
     fn concatenate_components(self) -> Vec<u8> {
         std::iter::once(self.flag)
-            .chain(self.version.value.as_bytes().iter().cloned())
+            .chain(self.version.to_bytes().iter().cloned())
             .chain(self.node_address.0.iter().cloned())
             .chain(self.delay.to_bytes().iter().cloned())
             .chain(self.header_integrity_mac.get_value().iter().cloned())
@@ -254,12 +256,14 @@ mod preparing_header_layer {
         let inner_layer_routing = encapsulated_routing_information_fixture();
 
         let version = Version {
-            value: env!("CARGO_PKG_VERSION").to_string(),
+            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
         };
         // calculate everything without using any object methods
         let concatenated_materials: Vec<u8> = [
             vec![FORWARD_HOP],
-            version.value.as_bytes().to_vec(),
+            version.to_bytes().to_vec(),
             node_address.0.to_vec(),
             delay.to_bytes().to_vec(),
             inner_layer_routing.integrity_mac.get_value_ref().to_vec(),
@@ -326,11 +330,13 @@ mod encrypting_routing_information {
         let next_routing = [8u8; TRUNCATED_ROUTING_INFO_SIZE];
 
         let version = Version {
-            value: env!("CARGO_PKG_VERSION").to_string(),
+            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
         };
         let encryption_data = [
             vec![flag],
-            version.value.as_bytes().to_vec(),
+            version.to_bytes().to_vec(),
             address.0.to_vec(),
             delay.to_bytes().to_vec(),
             mac.get_value_ref().to_vec(),
@@ -391,12 +397,14 @@ mod parse_decrypted_routing_information {
         let integrity_mac = header_integrity_mac_fixture().get_value();
         let next_routing_information = [1u8; ENCRYPTED_ROUTING_INFO_SIZE];
         let version = Version {
-            value: env!("CARGO_PKG_VERSION").to_string(),
+            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
+            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
+            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
         };
 
         let data = [
             vec![flag],
-            version.value.as_bytes().to_vec(),
+            version.to_bytes().to_vec(),
             address_fixture.0.to_vec(),
             delay.to_bytes().to_vec(),
             integrity_mac.to_vec(),

--- a/src/header/routing/nodes.rs
+++ b/src/header/routing/nodes.rs
@@ -390,10 +390,13 @@ mod parse_decrypted_routing_information {
         let delay = Delay::new(10);
         let integrity_mac = header_integrity_mac_fixture().get_value();
         let next_routing_information = [1u8; ENCRYPTED_ROUTING_INFO_SIZE];
+        let version = Version {
+            value: env!("CARGO_PKG_VERSION").to_string(),
+        };
 
         let data = [
             vec![flag],
-            [1u8; 5].to_vec(),
+            version.value.as_bytes().to_vec(),
             address_fixture.0.to_vec(),
             delay.to_bytes().to_vec(),
             integrity_mac.to_vec(),

--- a/src/header/routing/nodes.rs
+++ b/src/header/routing/nodes.rs
@@ -39,11 +39,7 @@ impl RoutingInformation {
     ) -> Self {
         RoutingInformation {
             flag: FORWARD_HOP,
-            version: Version {
-                major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
-                minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
-                patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
-            },
+            version: Version::new(),
             node_address,
             delay,
             header_integrity_mac: next_encapsulated_routing_information.integrity_mac,
@@ -255,11 +251,7 @@ mod preparing_header_layer {
         let previous_node_routing_keys = routing_keys_fixture();
         let inner_layer_routing = encapsulated_routing_information_fixture();
 
-        let version = Version {
-            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
-            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
-            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
-        };
+        let version = Version::new();
         // calculate everything without using any object methods
         let concatenated_materials: Vec<u8> = [
             vec![FORWARD_HOP],
@@ -329,11 +321,7 @@ mod encrypting_routing_information {
         let mac = header_integrity_mac_fixture();
         let next_routing = [8u8; TRUNCATED_ROUTING_INFO_SIZE];
 
-        let version = Version {
-            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
-            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
-            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
-        };
+        let version = Version::new();
         let encryption_data = [
             vec![flag],
             version.to_bytes().to_vec(),
@@ -396,11 +384,7 @@ mod parse_decrypted_routing_information {
         let delay = Delay::new(10);
         let integrity_mac = header_integrity_mac_fixture().get_value();
         let next_routing_information = [1u8; ENCRYPTED_ROUTING_INFO_SIZE];
-        let version = Version {
-            major: env!("CARGO_PKG_VERSION_MAJOR").to_string().parse().unwrap(),
-            minor: env!("CARGO_PKG_VERSION_MINOR").to_string().parse().unwrap(),
-            patch: env!("CARGO_PKG_VERSION_PATCH").to_string().parse().unwrap(),
-        };
+        let version = Version::new();
 
         let data = [
             vec![flag],


### PR DESCRIPTION
Updated (since the last time) adding a version to sphinx packet. Now, instead of having a version as a string x.x.x represented by 5 bytes, the version has three separate fields: major, minor and patch each of them being u8. 