### PR TITLE
Getting rid of .unwrap on the process method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,8 @@ impl SphinxPacket {
     }
 
     // TODO: we should have some list of 'seen shared_keys' for replay detection, but this should be handled by a mix node
-    pub fn process(self, node_secret_key: Scalar) -> ProcessedPacket {
-        let unwrapped_header = self.header.process(node_secret_key).unwrap();
+    pub fn process(self, node_secret_key: Scalar) -> Result<ProcessedPacket, SphinxUnwrapError> {
+        let unwrapped_header = self.header.process(node_secret_key)?;
         match unwrapped_header {
             ProcessedHeader::ProcessedHeaderForwardHop(
                 new_header,
@@ -66,11 +66,19 @@ impl SphinxPacket {
                     header: new_header,
                     payload: new_payload,
                 };
-                ProcessedPacket::ProcessedPacketForwardHop(new_packet, next_hop_address, delay)
+                Ok(ProcessedPacket::ProcessedPacketForwardHop(
+                    new_packet,
+                    next_hop_address,
+                    delay,
+                ))
             }
             ProcessedHeader::ProcessedHeaderFinalHop(destination, identifier, payload_key) => {
                 let new_payload = self.payload.unwrap(&payload_key);
-                ProcessedPacket::ProcessedPacketFinalHop(destination, identifier, new_payload)
+                Ok(ProcessedPacket::ProcessedPacketFinalHop(
+                    destination,
+                    identifier,
+                    new_payload,
+                ))
             }
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -38,7 +38,7 @@ mod create_and_process_sphinx_packet {
                 SphinxPacket { header, payload } => SphinxPacket { header, payload },
             };
 
-        let next_sphinx_packet_1 = match sphinx_packet.process(node1_sk) {
+        let next_sphinx_packet_1 = match sphinx_packet.process(node1_sk).unwrap() {
             ProcessedPacket::ProcessedPacketForwardHop(next_packet, next_hop_addr1, _delay1) => {
                 assert_eq!(NodeAddressBytes([4u8; NODE_ADDRESS_LENGTH]), next_hop_addr1);
                 next_packet
@@ -46,7 +46,7 @@ mod create_and_process_sphinx_packet {
             _ => panic!(),
         };
 
-        let next_sphinx_packet_2 = match next_sphinx_packet_1.process(node2_sk) {
+        let next_sphinx_packet_2 = match next_sphinx_packet_1.process(node2_sk).unwrap() {
             ProcessedPacket::ProcessedPacketForwardHop(next_packet, next_hop_addr2, _delay2) => {
                 assert_eq!(NodeAddressBytes([2u8; NODE_ADDRESS_LENGTH]), next_hop_addr2);
                 next_packet
@@ -54,7 +54,7 @@ mod create_and_process_sphinx_packet {
             _ => panic!(),
         };
 
-        match next_sphinx_packet_2.process(node3_sk) {
+        match next_sphinx_packet_2.process(node3_sk).unwrap() {
             ProcessedPacket::ProcessedPacketFinalHop(_, _, payload) => {
                 let zero_bytes = vec![0u8; SECURITY_PARAMETER];
                 let additional_padding = vec![
@@ -110,7 +110,7 @@ mod converting_sphinx_packet_to_and_from_bytes {
         let sphinx_packet_bytes = sphinx_packet.to_bytes();
         let recovered_packet = SphinxPacket::from_bytes(sphinx_packet_bytes).unwrap();
 
-        let next_sphinx_packet_1 = match recovered_packet.process(node1_sk) {
+        let next_sphinx_packet_1 = match recovered_packet.process(node1_sk).unwrap() {
             ProcessedPacket::ProcessedPacketForwardHop(next_packet, next_hop_address, delay) => {
                 assert_eq!(
                     NodeAddressBytes([4u8; NODE_ADDRESS_LENGTH]),
@@ -122,7 +122,7 @@ mod converting_sphinx_packet_to_and_from_bytes {
             _ => panic!(),
         };
 
-        let next_sphinx_packet_2 = match next_sphinx_packet_1.process(node2_sk) {
+        let next_sphinx_packet_2 = match next_sphinx_packet_1.process(node2_sk).unwrap() {
             ProcessedPacket::ProcessedPacketForwardHop(next_packet, next_hop_address, delay) => {
                 assert_eq!(
                     NodeAddressBytes([2u8; NODE_ADDRESS_LENGTH]),
@@ -134,7 +134,7 @@ mod converting_sphinx_packet_to_and_from_bytes {
             _ => panic!(),
         };
 
-        match next_sphinx_packet_2.process(node3_sk) {
+        match next_sphinx_packet_2.process(node3_sk).unwrap() {
             ProcessedPacket::ProcessedPacketFinalHop(_, _, payload) => {
                 let zero_bytes = vec![0u8; SECURITY_PARAMETER];
                 let additional_padding = vec![


### PR DESCRIPTION
Ensures that node key changes don't cause a panic on the running node
due to IntegrityMacErrors which we were seeing on our first deployed
mixnet.