### PR TITLE
Surb

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -25,7 +25,7 @@ pub struct SphinxHeader {
     pub routing_info: EncapsulatedRoutingInformation,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum SphinxError {
     IntegrityMacError,
     RoutingFlagNotRecognized,

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -6,7 +6,7 @@ use crate::header::keys::{BlindingFactor, PayloadKey, StreamCipherKey};
 use crate::header::routing::nodes::{EncryptedRoutingInformation, ParsedRawRoutingInformation};
 use crate::header::routing::{EncapsulatedRoutingInformation, ENCRYPTED_ROUTING_INFO_SIZE};
 use crate::route::{Destination, DestinationAddressBytes, Node, NodeAddressBytes, SURBIdentifier};
-use crate::{crypto, payload, ProcessingError};
+use crate::{crypto, payload, surb, ProcessingError};
 use curve25519_dalek::montgomery::MontgomeryPoint;
 use curve25519_dalek::scalar::Scalar;
 
@@ -32,11 +32,18 @@ pub enum SphinxError {
     ProcessingHeaderError,
     NotEnoughPayload,
     InvalidPayloadLengthError,
+    SURBError,
 }
 
 impl From<payload::PayloadEncapsulationError> for SphinxError {
     fn from(_: payload::PayloadEncapsulationError) -> Self {
         SphinxError::InvalidPayloadLengthError
+    }
+}
+
+impl From<surb::SURBError> for SphinxError {
+    fn from(_: surb::SURBError) -> Self {
+        SphinxError::SURBError
     }
 }
 

--- a/src/header/routing/nodes.rs
+++ b/src/header/routing/nodes.rs
@@ -11,7 +11,7 @@ use crate::header::routing::{
     EncapsulatedRoutingInformation, RoutingFlag, Version, ENCRYPTED_ROUTING_INFO_SIZE, FINAL_HOP,
     FORWARD_HOP, TRUNCATED_ROUTING_INFO_SIZE,
 };
-use crate::header::SphinxUnwrapError;
+use crate::header::SphinxError;
 use crate::route::{DestinationAddressBytes, NodeAddressBytes, SURBIdentifier};
 use crate::utils;
 
@@ -160,7 +160,7 @@ pub enum ParsedRawRoutingInformation {
 }
 
 impl RawRoutingInformation {
-    pub fn parse(self) -> Result<ParsedRawRoutingInformation, SphinxUnwrapError> {
+    pub fn parse(self) -> Result<ParsedRawRoutingInformation, SphinxError> {
         assert_eq!(
             NODE_META_INFO_SIZE + HEADER_INTEGRITY_MAC_SIZE + ENCRYPTED_ROUTING_INFO_SIZE,
             self.value.len()
@@ -170,7 +170,7 @@ impl RawRoutingInformation {
         match flag {
             FORWARD_HOP => Ok(self.parse_as_forward_hop()),
             FINAL_HOP => Ok(self.parse_as_final_hop()),
-            _ => Err(SphinxUnwrapError::RoutingFlagNotRecognized),
+            _ => Err(SphinxError::RoutingFlagNotRecognized),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod header;
 pub mod key;
 pub mod payload;
 pub mod route;
+pub mod surb;
 mod utils;
 
 pub const PACKET_SIZE: usize = HEADER_SIZE + PAYLOAD_SIZE;

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -1,7 +1,10 @@
+use crate::constants::{DESTINATION_ADDRESS_LENGTH, PAYLOAD_SIZE, SECURITY_PARAMETER};
 use crate::header::delays::Delay;
 use crate::header::keys::PayloadKey;
+use crate::header::SphinxError;
+use crate::payload::Payload;
 use crate::route::{Destination, Node, NodeAddressBytes};
-use crate::{crypto, header};
+use crate::{crypto, header, SphinxPacket};
 use curve25519_dalek::scalar::Scalar;
 
 #[derive(Clone)]
@@ -11,11 +14,11 @@ pub struct SURB {
     /// used to layer encrypt the payload.
     pub SURBHeader: header::SphinxHeader,
     pub first_hop_address: NodeAddressBytes,
-    pub payload_key_material: Vec<PayloadKey>,
+    pub payload_keys: Vec<PayloadKey>,
 }
 
 #[derive(Debug)]
-pub enum SURBCreationError {
+pub enum SURBError {
     IncorrectSURBRoute,
 }
 
@@ -25,7 +28,7 @@ impl SURB {
         surb_route: &[Node],
         surb_delays: &[Delay],
         surb_destination: &Destination,
-    ) -> Result<Self, SURBCreationError> {
+    ) -> Result<Self, SURBError> {
         assert_eq!(surb_route.len(), surb_delays.len());
 
         let (header, payload_keys) = header::SphinxHeader::new(
@@ -35,14 +38,33 @@ impl SURB {
             surb_destination,
         );
 
-        let first_hop = surb_route
-            .first()
-            .ok_or(SURBCreationError::IncorrectSURBRoute)?;
+        let first_hop = surb_route.first().ok_or(SURBError::IncorrectSURBRoute)?;
 
         Ok(SURB {
             SURBHeader: header,
             first_hop_address: first_hop.address.clone(),
-            payload_key_material: payload_keys,
+            payload_keys: payload_keys,
         })
+    }
+
+    pub fn use_surb(
+        self,
+        plaintext_message: &[u8],
+        surb_destination: &Destination,
+    ) -> Result<SphinxPacket, SphinxError> {
+        let header = self.SURBHeader;
+
+        if plaintext_message.len() + DESTINATION_ADDRESS_LENGTH > PAYLOAD_SIZE - SECURITY_PARAMETER
+        {
+            return Err(SphinxError::NotEnoughPayload);
+        };
+
+        let payload = Payload::encapsulate_message(
+            &plaintext_message,
+            &self.payload_keys,
+            surb_destination.address.clone(),
+        )?;
+
+        Ok(SphinxPacket { header, payload })
     }
 }

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -36,7 +36,7 @@ impl SURB {
         );
 
         let first_hop = surb_route
-            .last()
+            .first()
             .ok_or(SURBCreationError::IncorrectSURBRoute)?;
 
         Ok(SURB {

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -9,9 +9,9 @@ use curve25519_dalek::scalar::Scalar;
 
 #[derive(Clone)]
 pub struct SURB {
-    /// A Single Use Reply Block (SURB) must have a pre-aggregated Sphinx header,
-    /// the address of the first hop in the route of the SURB, and the key material
-    /// used to layer encrypt the payload.
+    /* A Single Use Reply Block (SURB) must have a pre-aggregated Sphinx header,
+    the address of the first hop in the route of the SURB, and the key material
+    used to layer encrypt the payload. */
     pub SURBHeader: header::SphinxHeader,
     pub first_hop_address: NodeAddressBytes,
     pub payload_keys: Vec<PayloadKey>,
@@ -20,6 +20,7 @@ pub struct SURB {
 #[derive(Debug, PartialEq)]
 pub enum SURBError {
     IncorrectSURBRoute,
+    LengthsNotMatching,
 }
 
 impl SURB {
@@ -29,11 +30,13 @@ impl SURB {
         surb_delays: &[Delay],
         surb_destination: &Destination,
     ) -> Result<Self, SURBError> {
-        /// Precomputes the header of the Sphinx packet which will be used as SURB
-        /// and encapsulates it into struct together with the address of the first hop in the route of the SURB, and the key material
-        /// which should be used to layer encrypt the payload.
-        assert_eq!(surb_route.len(), surb_delays.len());
+        /* Pre-computes the header of the Sphinx packet which will be used as SURB
+        and encapsulates it into struct together with the address of the first hop in the route of the SURB, and the key material
+        which should be used to layer encrypt the payload. */
 
+        if surb_route.len() != surb_delays.len() {
+            return Err(SURBError::LengthsNotMatching);
+        };
         let first_hop = surb_route.first().ok_or(SURBError::IncorrectSURBRoute)?;
 
         let (header, payload_keys) = header::SphinxHeader::new(
@@ -55,9 +58,10 @@ impl SURB {
         plaintext_message: &[u8],
         surb_destination: &Destination,
     ) -> Result<(SphinxPacket, NodeAddressBytes), SphinxError> {
-        /// Function takes the precomputed surb header, layer encrypts the plaintext payload content
-        /// using the precomputed payload key material and returns the full Sphinx packet
-        /// together with the address of first hop to which it should be forwarded.
+        /* Function takes the precomputed surb header, layer encrypts the plaintext payload content
+        using the precomputed payload key material and returns the full Sphinx packet
+        together with the address of first hop to which it should be forwarded. */
+
         let header = self.SURBHeader;
 
         if plaintext_message.len() + DESTINATION_ADDRESS_LENGTH > PAYLOAD_SIZE - SECURITY_PARAMETER

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -51,7 +51,7 @@ impl SURB {
         self,
         plaintext_message: &[u8],
         surb_destination: &Destination,
-    ) -> Result<SphinxPacket, SphinxError> {
+    ) -> Result<(SphinxPacket, NodeAddressBytes), SphinxError> {
         let header = self.SURBHeader;
 
         if plaintext_message.len() + DESTINATION_ADDRESS_LENGTH > PAYLOAD_SIZE - SECURITY_PARAMETER
@@ -65,6 +65,6 @@ impl SURB {
             surb_destination.address.clone(),
         )?;
 
-        Ok(SphinxPacket { header, payload })
+        Ok((SphinxPacket { header, payload }, self.first_hop_address))
     }
 }

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -1,0 +1,9 @@
+use crate::header;
+use crate::header::keys::PayloadKey;
+use crate::route::NodeAddressBytes;
+
+pub struct SURB {
+    pub SURBHeader: header::SphinxHeader,
+    pub first_hop_address: NodeAddressBytes,
+    pub payload_key_material: Vec<PayloadKey>,
+}

--- a/src/surb/mod.rs
+++ b/src/surb/mod.rs
@@ -1,9 +1,48 @@
-use crate::header;
+use crate::header::delays::Delay;
 use crate::header::keys::PayloadKey;
-use crate::route::NodeAddressBytes;
+use crate::route::{Destination, Node, NodeAddressBytes};
+use crate::{crypto, header};
+use curve25519_dalek::scalar::Scalar;
 
+#[derive(Clone)]
 pub struct SURB {
+    /// A Single Use Reply Block (SURB) must have a pre-aggregated Sphinx header,
+    /// the address of the first hop in the route of the SURB, and the key material
+    /// used to layer encrypt the payload.
     pub SURBHeader: header::SphinxHeader,
     pub first_hop_address: NodeAddressBytes,
     pub payload_key_material: Vec<PayloadKey>,
+}
+
+#[derive(Debug)]
+pub enum SURBCreationError {
+    IncorrectSURBRoute,
+}
+
+impl SURB {
+    pub fn new(
+        surb_initial_secret: Scalar,
+        surb_route: &[Node],
+        surb_delays: &[Delay],
+        surb_destination: &Destination,
+    ) -> Result<Self, SURBCreationError> {
+        assert_eq!(surb_route.len(), surb_delays.len());
+
+        let (header, payload_keys) = header::SphinxHeader::new(
+            surb_initial_secret,
+            surb_route,
+            surb_delays,
+            surb_destination,
+        );
+
+        let first_hop = surb_route
+            .last()
+            .ok_or(SURBCreationError::IncorrectSURBRoute)?;
+
+        Ok(SURB {
+            SURBHeader: header,
+            first_hop_address: first_hop.address.clone(),
+            payload_key_material: payload_keys,
+        })
+    }
 }


### PR DESCRIPTION
The branch SURB implements the Single Use Reply Block. It is added in an Optional Way, for now, to ensure that even if we merge the branch, the code will be still stable. The SURB is (optionally) created when the Sphinx packet is created and added into the payload (next to the plaintext message we want to send. )

It would be good to have a look whether any more test covarage is needed. 

In order to properly use SURBs you need to also edit the code for the Nym Client, but this depends on how we decide to use the SURB. This is something to discuss soon.