### PR TITLE
Allow for RNG propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ blake2 = "0.8.0" # cannot be updated due to outdated dependency inside lioness
 byteorder = "1.3.2"
 subtle = "2.3.0"
 
-
 [dev-dependencies]
 mockall = "0.10.2"
 criterion = "0.3"
+rand_chacha = "0.2.2"
 
 [[bench]]
 name = "benchmarks"

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -66,8 +66,7 @@ impl PrivateKey {
     // honestly, this method shouldn't really exist, but right now we have no decent
     // rng propagation in the library
     pub fn new() -> Self {
-        let mut rng = OsRng;
-        Self::new_with_rng(&mut rng)
+        Self::new_with_rng(&mut OsRng)
     }
 
     pub fn new_with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
@@ -145,7 +144,11 @@ impl PartialEq for PublicKey {
 impl Eq for PublicKey {}
 
 pub fn keygen() -> (PrivateKey, PublicKey) {
-    let private_key = PrivateKey::new();
+    keygen_with_rng(&mut OsRng)
+}
+
+pub fn keygen_with_rng<R: RngCore + CryptoRng>(rng: &mut R) -> (PrivateKey, PublicKey) {
+    let private_key = PrivateKey::new_with_rng(rng);
     let public_key = PublicKey::from(&private_key);
     (private_key, public_key)
 }

--- a/src/header/delays.rs
+++ b/src/header/delays.rs
@@ -14,6 +14,8 @@
 
 use crate::constants::DELAY_LENGTH;
 use byteorder::{BigEndian, ByteOrder};
+use rand::rngs::OsRng;
+use rand::{CryptoRng, RngCore};
 use rand_distr::{Distribution, Exp};
 use std::{borrow::Borrow, time::Duration};
 
@@ -105,11 +107,19 @@ pub fn generate_from_nanos(number: usize, average_delay: u64) -> Vec<Delay> {
 }
 
 pub fn generate_from_average_duration(number: usize, average_delay: Duration) -> Vec<Delay> {
+    generate_from_average_duration_with_rng(number, average_delay, &mut OsRng)
+}
+
+pub fn generate_from_average_duration_with_rng<R: RngCore + CryptoRng>(
+    number: usize,
+    average_delay: Duration,
+    rng: &mut R,
+) -> Vec<Delay> {
     let exp = Exp::new(1.0 / average_delay.as_nanos() as f64).unwrap();
 
     std::iter::repeat(())
         .take(number)
-        .map(|_| Delay::new_from_nanos(exp.sample(&mut rand::thread_rng()).round() as u64))
+        .map(|_| Delay::new_from_nanos(exp.sample(rng).round() as u64))
         .collect()
 }
 

--- a/src/packet/builder.rs
+++ b/src/packet/builder.rs
@@ -40,9 +40,9 @@ impl<'a> SphinxPacketBuilder<'a> {
         self.build_packet_with_rng(message, route, destination, delays, &mut OsRng)
     }
 
-    pub fn build_packet_with_rng<R: RngCore + CryptoRng>(
+    pub fn build_packet_with_rng<R: RngCore + CryptoRng, M: AsRef<[u8]>>(
         &self,
-        message: Vec<u8>,
+        message: M,
         route: &[Node],
         destination: &Destination,
         delays: &[Delay],


### PR DESCRIPTION
**Summary**

Currently the Sphinx library is using `OsRng` (and sometimes `ThreadRng`) internally in some places that a caller cannot control. For example, inside the `add_padding` method which has non-public visibility. Hence, a caller who wants to use a different (P)RNG cannot easily do so.

This diff allows callers to provide a `Rng` for the top-level methods which is then passed through.

Following the existing pattern in `EphemeralSecret::new_with_rng`, I have added a new `new_with_rng` function in all places where necessary. We might want to consider to just change the existing `new` function instead, but that would be a breaking change of the public API.

See also this existing comment: https://github.com/lambdapioneer/nym-sphinx/blob/develop/src/crypto/keys.rs#L66-L67

```
    // honestly, this method shouldn't really exist, but right now we have no decent
    // rng propagation in the library
```

P.S. I enjoyed working in the code base :) well structured

**Background**

My personal motivation for this change is that we have an overlay protocol where multiple participants must generate the same SURB and then distribute it via secret shares. For this purpose I want to pass in a PRNG that's seeded with a nonce.

**Test plan**

I have added tests that verify that all output bytes rely on the passed-in RNG.

```shell
$ cargo test -q

running 80 tests
................................................................................
test result: ok. 80 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 4 tests
....
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```