### PR TITLE
Fix clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sphinx"
 version = "0.1.0"
 authors = ["Ania Piotrowska <ania@nymtech.net>", "Dave Hrycyszyn <futurechimp@users.noreply.github.com>", "Jędrzej Stuczyński <andrew@nymtech.net>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/crypto/keys.rs
+++ b/src/crypto/keys.rs
@@ -44,7 +44,7 @@ pub fn clamp_scalar_bytes(mut scalar_bytes: [u8; PRIVATE_KEY_SIZE]) -> Scalar {
 // derive zeroize::Zeroize on drop here
 pub struct PrivateKey(Scalar);
 
-#[allow(clippy::derive_hash_xor_eq)] // TODO: we must be careful about that one if anything changes in the future
+#[allow(clippy::derived_hash_with_manual_eq)] // TODO: we must be careful about that one if anything changes in the future
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct PublicKey(MontgomeryPoint);
 


### PR DESCRIPTION
Update a rename clippy warning

```
error: lint `clippy::derive_hash_xor_eq` has been renamed to `clippy::derived_hash_with_manual_eq
```